### PR TITLE
Publish automatically from releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+on:
+  release:
+    types:
+      - created
+jobs:
+  crates-io:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Publish
+        run: cargo publish
+  vscode-marketplace:
+    runs-on: ubuntu-18.04
+    defaults:
+      run:
+        working-directory: editors/code
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Publish
+        run: npx vsce publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Publish
-        run: npx vsce publish
+        run: npx vsce publish --baseImagesUrl="https://github.com/samestep/quench/raw/${GITHUB_REF#refs/tags/}/editors/code"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           toolchain: stable
       - name: Publish
-        run: cargo publish
+        run: cargo publish --token ${{ secrets.CARGO_TOKEN }}
   vscode-marketplace:
     runs-on: ubuntu-18.04
     defaults:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,3 +29,5 @@ jobs:
         run: npm install
       - name: Publish
         run: npx vsce publish --baseImagesUrl="https://github.com/samestep/quench/raw/${GITHUB_REF#refs/tags/}/editors/code"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -53,6 +53,7 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
+    "vscode:prepublish": "npm run compile",
     "lint": "eslint src --ext ts",
     "pretest": "npm run compile && npm run lint",
     "test": "node ./out/test/runTest.js"


### PR DESCRIPTION
- [x] Write a workflow that's triggered by the [`release`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release) event
- [x] Use a [pre-publish step](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prepublish-step) to ensure that the TypeScript files get compiled as specified in #14
- [x] [Set `--baseImagesUrl`](https://github.com/quench-lang/quench/pull/14) for `vsce publish`
- [x] Configure the [`VSCE_PAT` secret](https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions-automated-publishing)
- [x] Configure the necessary secret(s) for `cargo publish`