### PR TITLE
Ensure empty Git status at end of CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Node
         uses: actions/setup-node@v2
+        with:
+          node-version: 15
       - name: Install dependencies
         run: npm install
       - name: Generate Tree-sitter parser
@@ -59,6 +61,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Node
         uses: actions/setup-node@v2
+        with:
+          node-version: 15
       - name: Install dependencies
         run: npm install
       - name: Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         run: npx tree-sitter generate
       - name: Test parser
         run: npx tree-sitter test
+      - name: Ensure empty Git status
+        run: "$GITHUB_WORKSPACE/report_git_status.sh"
   rust:
     runs-on: ubuntu-18.04
     steps:
@@ -44,6 +46,8 @@ jobs:
         with:
           name: quench-lsp
           path: '~/.cargo/bin/quench-lsp'
+      - name: Ensure empty Git status
+        run: "$GITHUB_WORKSPACE/report_git_status.sh"
   vscode:
     needs: rust
     runs-on: ubuntu-18.04
@@ -69,3 +73,5 @@ jobs:
           sudo mv $GITHUB_WORKSPACE/quench-lsp /usr/local/bin
       - name: Run tests
         run: xvfb-run -a npm test
+      - name: Ensure empty Git status
+        run: "$GITHUB_WORKSPACE/report_git_status.sh"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Node
         uses: actions/setup-node@v2
+        with:
+          node-version: 15
       - name: Install dependencies
         run: npm install
       - name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
           toolchain: stable
       - name: Publish
         run: cargo publish --token ${{ secrets.CARGO_TOKEN }}
+      - name: Ensure empty Git status
+        run: "$GITHUB_WORKSPACE/report_git_status.sh"
   vscode-marketplace:
     runs-on: ubuntu-18.04
     defaults:
@@ -31,3 +33,5 @@ jobs:
         run: npx vsce publish --baseImagesUrl="https://github.com/quench-lang/quench/raw/${GITHUB_REF#refs/tags/}/editors/code"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      - name: Ensure empty Git status
+        run: "$GITHUB_WORKSPACE/report_git_status.sh"

--- a/editors/code/.gitignore
+++ b/editors/code/.gitignore
@@ -1,3 +1,4 @@
 /.vscode-test/
+/*.vsix
 /node_modules/
 /out/

--- a/report_git_status.sh
+++ b/report_git_status.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 CHANGES=$(git status --porcelain)
 echo "$CHANGES"
+git diff
 [ -z "$CHANGES" ]

--- a/report_git_status.sh
+++ b/report_git_status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+CHANGES=$(git status --porcelain)
+echo "$CHANGES"
+[ -z "$CHANGES" ]


### PR DESCRIPTION
This allows CI to catch things like

- [`package-lock.json` being out of date](https://github.com/quench-lang/quench/commit/009607ac07a1489a73a1e358b1edabffc0a35bb1#diff-5327de443060217a48dced224bfca8b87dc60e5f9b3f8550c4782776295121f0)
- [gaps in `.gitignore`](https://github.com/quench-lang/quench/commit/fcd75de05e0c4b7ccfc3cf5609ccf9111788f962)
- [out-of-date `npm` causing the wrong `lockfileVersion` to be used](https://github.com/quench-lang/quench/commit/8ed87e667ff5381ba89de9e9562a5f926a8b732f)