### PR TITLE
Add badge for minimum rustc version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Ensure empty Git status
         run: "$GITHUB_WORKSPACE/report_git_status.sh"
   rust:
+    strategy:
+      matrix:
+        rust:
+          - 1.46.0
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -33,7 +37,9 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.44.1
+          toolchain: ${{ matrix.rust }}
+      - name: Set Rust toolchain
+        run: rustup default ${{ matrix.rust }}
       - name: Get dependencies from cache
         uses: Swatinem/rust-cache@v1
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0
+          - 1.48.0
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+
 jobs:
   tree-sitter:
     runs-on: ubuntu-18.04
@@ -25,6 +26,7 @@ jobs:
         run: npx tree-sitter test
       - name: Ensure empty Git status
         run: "$GITHUB_WORKSPACE/report_git_status.sh"
+
   rust:
     strategy:
       matrix:
@@ -56,6 +58,7 @@ jobs:
           path: '~/.cargo/bin/quench-lsp'
       - name: Ensure empty Git status
         run: "$GITHUB_WORKSPACE/report_git_status.sh"
+
   vscode:
     needs: rust
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.44.1
       - name: Get dependencies from cache
         uses: Swatinem/rust-cache@v1
       - name: Run tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   release:
     types:
       - created
+
 jobs:
   crates-io:
     runs-on: ubuntu-18.04
@@ -17,6 +18,7 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_TOKEN }}
       - name: Ensure empty Git status
         run: "$GITHUB_WORKSPACE/report_git_status.sh"
+
   vscode-marketplace:
     runs-on: ubuntu-18.04
     defaults:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +195,25 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "comrak"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac96caba4b5b55c21c9efd51d498225ce9448d06d9d5c17bbd357522c71bacfd"
+dependencies = [
+ "clap",
+ "entities",
+ "lazy_static",
+ "pest",
+ "pest_derive",
+ "regex",
+ "shell-words",
+ "twoway",
+ "typed-arena",
+ "unicode_categories",
+ "xdg",
 ]
 
 [[package]]
@@ -207,10 +259,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "form_urlencoded"
@@ -321,6 +394,15 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -444,6 +526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "lock_api"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +598,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
@@ -590,6 +684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +728,49 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -737,11 +880,13 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "cc",
+ "comrak",
  "futures",
  "goldenfile",
  "im",
  "lspower",
  "pretty_assertions",
+ "regex",
  "salsa",
  "serde_json",
  "slurp",
@@ -753,6 +898,7 @@ dependencies = [
  "toml",
  "tree-sitter",
  "url",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -955,6 +1101,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1219,10 +1383,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
+name = "twoway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b40075910de3a912adbd80b5d8bad6ad10a23eeb1f5bf9d4006839e899ba5bc"
+dependencies = [
+ "memchr",
+ "unchecked-index",
+]
+
+[[package]]
+name = "typed-arena"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
+
+[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unchecked-index"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicode-bidi"
@@ -1259,6 +1451,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"
@@ -1327,3 +1525,18 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "xdg"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,10 @@ cc = "1"
 
 [dev-dependencies]
 assert_cmd = "1"
+comrak = "0.10"
 goldenfile = "1"
 pretty_assertions = "0.7"
+regex = "1"
 serde_json = "1"
 toml = "0.5"
+yaml-rust = "0.4"

--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ from me and not my employer (Facebook)._
 [editors]: /editors
 [tree-sitter-quench]: /tree-sitter-quench
 [rust]: https://www.rust-lang.org/tools/install
-[rust release]: https://github.com/rust-lang/rust/blob/1.46.0/RELEASES.md#language
-[rustc version]: https://img.shields.io/badge/rustc-1.46+-lightgray.svg
+[rust release]: https://github.com/rust-lang/rust/blob/1.48.0/RELEASES.md#libraries
+[rustc version]: https://img.shields.io/badge/rustc-1.48+-lightgray.svg

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quench [![crates.io][]][crates.io link] [![docs.rs][]][docs.rs link] [![rustc version][]][rust 1.46.0]
+# Quench [![crates.io][]][crates.io link] [![docs.rs][]][docs.rs link] [![rustc version][]][rust release]
 
 A programming language.
 
@@ -51,5 +51,5 @@ from me and not my employer (Facebook)._
 [editors]: /editors
 [tree-sitter-quench]: /tree-sitter-quench
 [rust]: https://www.rust-lang.org/tools/install
-[rust 1.46.0]: https://github.com/rust-lang/rust/blob/1.46.0/RELEASES.md#language
+[rust release]: https://github.com/rust-lang/rust/blob/1.46.0/RELEASES.md#language
 [rustc version]: https://img.shields.io/badge/rustc-1.46+-lightgray.svg

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quench [![crates.io][]][crates.io link] [![docs.rs][]][docs.rs link]
+# Quench [![crates.io][]][crates.io link] [![docs.rs][]][docs.rs link] [![rustc version][]][rust 1.46.0]
 
 A programming language.
 
@@ -51,3 +51,5 @@ from me and not my employer (Facebook)._
 [editors]: /editors
 [tree-sitter-quench]: /tree-sitter-quench
 [rust]: https://www.rust-lang.org/tools/install
+[rust 1.46.0]: https://github.com/rust-lang/rust/blob/1.46.0/RELEASES.md#language
+[rustc version]: https://img.shields.io/badge/rustc-1.46+-lightgray.svg

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -52,7 +52,7 @@ fn test_minimum_rustc() {
         ));
 
         let mut versions = HashSet::new();
-        let re = Regex::new(r"rustc-(\d+\.\d+)").unwrap();
+        let re = Regex::new(r"rustc-(\d+\.\d+)\+").unwrap();
         for node in heading.children() {
             if let comrak::nodes::NodeValue::Link(comrak::nodes::NodeLink { .. }) =
                 &node.data.borrow().value
@@ -75,7 +75,7 @@ fn test_minimum_rustc() {
     assert!(!readme_versions.is_empty());
 
     let ci_versions: HashSet<String> = {
-        let re = Regex::new(r"^\d+\.\d+").unwrap();
+        let re = Regex::new(r"^(\d+\.\d+)\.\d+$").unwrap();
         YamlLoader::load_from_str(&slurp::read_all_to_string(".github/workflows/ci.yml").unwrap())
             .unwrap()
             .get(0)
@@ -103,8 +103,8 @@ fn test_minimum_rustc() {
             .as_vec()
             .unwrap()
             .iter()
-            .filter_map(|version| re.find(version.as_str().unwrap()))
-            .map(|m| String::from(m.as_str()))
+            .filter_map(|version| re.captures(version.as_str().unwrap()))
+            .map(|m| String::from(&m[1]))
             .collect()
     };
     assert!(

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use comrak::ComrakOptions;
+use regex::Regex;
+use std::{collections::HashSet, path::PathBuf, str};
+use yaml_rust::{Yaml, YamlLoader};
 
 #[test]
 fn test_version() {
@@ -30,4 +33,84 @@ fn test_version() {
             path.display(),
         );
     }
+}
+
+#[test]
+fn test_minimum_rustc() {
+    let readme_versions: HashSet<String> = {
+        let arena = comrak::Arena::new();
+        let heading = comrak::parse_document(
+            &arena,
+            &slurp::read_all_to_string("README.md").unwrap(),
+            &ComrakOptions::default(),
+        )
+        .first_child()
+        .unwrap();
+        assert!(matches!(
+            heading.data.borrow().value,
+            comrak::nodes::NodeValue::Heading(comrak::nodes::NodeHeading { level: 1, .. }),
+        ));
+
+        let mut versions = HashSet::new();
+        let re = Regex::new(r"rustc-(\d+\.\d+)").unwrap();
+        for node in heading.children() {
+            if let comrak::nodes::NodeValue::Link(comrak::nodes::NodeLink { .. }) =
+                &node.data.borrow().value
+            {
+                if let Some(inner) = node.first_child() {
+                    if let comrak::nodes::NodeValue::Image(comrak::nodes::NodeLink {
+                        url, ..
+                    }) = &inner.data.borrow().value
+                    {
+                        // if we got here, node is a badge
+                        if let Some(m) = re.captures(str::from_utf8(url).unwrap()) {
+                            versions.insert(String::from(&m[1]));
+                        }
+                    }
+                }
+            }
+        }
+        versions
+    };
+    assert!(!readme_versions.is_empty());
+
+    let ci_versions: HashSet<String> = {
+        let re = Regex::new(r"^\d+\.\d+").unwrap();
+        YamlLoader::load_from_str(&slurp::read_all_to_string(".github/workflows/ci.yml").unwrap())
+            .unwrap()
+            .get(0)
+            .unwrap()
+            .as_hash()
+            .unwrap()
+            .get(&Yaml::String(String::from("jobs")))
+            .unwrap()
+            .as_hash()
+            .unwrap()
+            .get(&Yaml::String(String::from("rust")))
+            .unwrap()
+            .as_hash()
+            .unwrap()
+            .get(&Yaml::String(String::from("strategy")))
+            .unwrap()
+            .as_hash()
+            .unwrap()
+            .get(&Yaml::String(String::from("matrix")))
+            .unwrap()
+            .as_hash()
+            .unwrap()
+            .get(&Yaml::String(String::from("rust")))
+            .unwrap()
+            .as_vec()
+            .unwrap()
+            .iter()
+            .filter_map(|version| re.find(version.as_str().unwrap()))
+            .map(|m| String::from(m.as_str()))
+            .collect()
+    };
+    assert!(
+        readme_versions.is_subset(&ci_versions),
+        "README rustc versions {:?} should be a subset of CI Rust versions {:?}",
+        readme_versions,
+        ci_versions,
+    );
 }


### PR DESCRIPTION
Currently Quench [fails to compile with Rust 1.44.1](https://github.com/rust-lang/rust/issues/49146), so this PR aims to reduce confusion by

- [x] adding a README badge showing the minimum supported `rustc` version (as [`serde_json`](https://github.com/serde-rs/json/tree/d735585370d3d62502130051529410464e147224) and [`rand`](https://github.com/rust-random/rand/tree/5760aedfd626f0c825e9e509bb6c95fdc64e5467) do),
- [x] using that version in CI, and
- [x] ensuring that those two version numbers stay in sync with each other (along similar lines to #22).