### PR TITLE
Trim Rust and VS Code packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,23 @@ jobs:
       - name: Ensure empty Git status
         run: "$GITHUB_WORKSPACE/report_git_status.sh"
 
+  package:
+    runs-on: ubuntu-18.04
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      # don't pull from cache, because cargo package doesn't seem to benefit
+      - name: Package
+        run: cargo package
+      - name: Ensure empty Git status
+        run: "$GITHUB_WORKSPACE/report_git_status.sh"
+
   rust:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,13 @@ categories = [
   "compilers",
   "development-tools",
 ]
+include = [
+  "/build.rs",
+  "/LICENSE",
+  "/README.md",
+  "/src",
+  "/tree-sitter-quench/src",
+]
 default-run = "quench"
 
 [[bin]]

--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -1,0 +1,2 @@
+**/*.ts
+**/tsconfig.json


### PR DESCRIPTION
The `editors/code/.vscodeignore` file is mostly copied from [the link that keeps appearing in the VS Code CI logs](https://aka.ms/vscode-vscodeignore). This PR doesn't make that message go away, but it does significantly decrease the VSIX package size.

I added a separate new job for `cargo package` because it's fairly slow (since it doesn't seem to use the cache) and so the `vscode` job shouldn't need to depend on it.