### PR TITLE
Add license field in VS Code extension manifest

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "quench",
       "version": "0.1.2",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "vscode-languageclient": "^7.0.0"
       },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "version": "0.1.2",
   "publisher": "quench",
+  "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
     "url": "https://github.com/quench-lang/quench.git",


### PR DESCRIPTION
As instructed here: https://code.visualstudio.com/api/references/extension-manifest#fields