### PR TITLE
Fix tree-sitter-quench package.json

### DIFF
--- a/tree-sitter-quench/.gitignore
+++ b/tree-sitter-quench/.gitignore
@@ -1,3 +1,4 @@
 /binding.gyp
+/build/
 /index.js
 /node_modules/

--- a/tree-sitter-quench/package-lock.json
+++ b/tree-sitter-quench/package-lock.json
@@ -6,9 +6,17 @@
   "packages": {
     "": {
       "version": "0.1.2",
+      "dependencies": {
+        "nan": "^2.14.2"
+      },
       "devDependencies": {
         "tree-sitter-cli": "^0.17"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "node_modules/tree-sitter-cli": {
       "version": "0.17.3",
@@ -22,6 +30,11 @@
     }
   },
   "dependencies": {
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
     "tree-sitter-cli": {
       "version": "0.17.3",
       "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.17.3.tgz",

--- a/tree-sitter-quench/package.json
+++ b/tree-sitter-quench/package.json
@@ -2,6 +2,9 @@
   "name": "tree-sitter-quench",
   "version": "0.1.2",
   "description": "",
+  "dependencies": {
+    "nan": "^2.14.2"
+  },
   "devDependencies": {
     "tree-sitter-cli": "^0.17"
   }


### PR DESCRIPTION
The [Tree-sitter documentation](https://tree-sitter.github.io/tree-sitter/creating-parsers#project-setup) specifically says to add `nan` as a dependency, but I didn't for some reason. Before this PR, if you run the following in sequence:
```sh
npm install
npx tree-sitter generate
npm install
```
you'd get an error message saying (among other things):
```
Error: Cannot find module 'nan'
```