### PR TITLE
Don't fail publish-binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   binaries:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - platform: linux
@@ -46,8 +47,6 @@ jobs:
           asset_path: ./target/release/quench-lsp${{ matrix.extension }}
           asset_name: quench-lsp-${{ matrix.platform }}${{ matrix.extension }}
           asset_content_type: application/octet-stream
-      - name: Ensure empty Git status
-        run: "$GITHUB_WORKSPACE/report_git_status.sh"
 
   crates-io:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This effectively reverts #37 since [that step was failing on Windows](https://github.com/quench-lang/quench/runs/2199105203?check_suite_focus=true), and also prevents such failures from [affecting other jobs in the same matrix](https://github.com/quench-lang/quench/runs/2199105183?check_suite_focus=true).