### PR TITLE
Fix some README issues for version 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "quench"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quench"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Sam Estep <sam@samestep.com>"]
 edition = "2018"
 description = "A programming language."

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ chmod +x quench
 sudo mv quench /usr/local/bin
 ```
 
-### macOS
+### macOS 10
 
 ```sh
 curl -o quench -L https://github.com/quench-lang/quench/releases/latest/download/quench-macos
@@ -85,7 +85,7 @@ from me and not my employer (Facebook)._
 [docs.rs]: https://docs.rs/quench/badge.svg
 [docs.rs link]: https://docs.rs/quench
 [editors]: /editors
-[quench-windows.exe]: https://github.com/quench-lang/quench/releases/download/latest/quench-windows.exe
+[quench-windows.exe]: https://github.com/quench-lang/quench/releases/latest/download/quench-windows.exe
 [tree-sitter-quench]: /tree-sitter-quench
 [rust]: https://www.rust-lang.org/tools/install
 [rust release]: https://github.com/rust-lang/rust/blob/1.48.0/RELEASES.md#libraries

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -1,9 +1,9 @@
-# VS Code extension for Quench
+# [VS Code extension for Quench][marketplace]
 
 This extension provides support for the [Quench][] language via a [language
 server][lsp], which it automatically downloads if you don't already have it
-installed. To use, simply install the extension, click the "Download" button if
-prompted, and open a file with extension `.qn`:
+installed. To use, simply install this extension, open any file whose name ends
+with `.qn`, and click the "Download" button if prompted.
 
 ![screnshot of hello.qn in VS Code](hello.png)
 
@@ -36,6 +36,7 @@ Then open a Quench source file (such as `examples/hello.qn` from this
 repository) to activate it as normal.
 
 [lsp]: https://microsoft.github.io/language-server-protocol/
+[marketplace]: https://marketplace.visualstudio.com/items?itemName=quench.quench
 [node]: https://github.com/nvm-sh/nvm#install--update-script
 [quench]: https://github.com/quench-lang/quench
 [vs code]: https://code.visualstudio.com/download

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quench",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "quench",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "follow-redirects": "^1.13.3",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "quench",
   "displayName": "Quench",
   "description": "",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "quench",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {

--- a/tests/goldenfiles/help.txt
+++ b/tests/goldenfiles/help.txt
@@ -1,4 +1,4 @@
-quench 0.2.2
+quench 0.2.3
 
 Here is an example Quench program:
 

--- a/tree-sitter-quench/package-lock.json
+++ b/tree-sitter-quench/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tree-sitter-quench",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "nan": "^2.14.2"
       },

--- a/tree-sitter-quench/package.json
+++ b/tree-sitter-quench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-quench",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "dependencies": {
     "nan": "^2.14.2"


### PR DESCRIPTION
- [x] Correct the Windows download URL
- [x] Correct the order of operations in the VS Code extension README
- [x] Clarify that the macOS binaries are just for macOS 10
- [x] Link to the VS Code extension page from its README in the repo
- [x] Bump the version to 0.2.3