### PR TITLE
Make quench-lsp a subcommand of quench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,11 @@ jobs:
       # partially covered by tests/cli.rs, but this checks the shebang
       - name: Check output of hello example
         run: examples/hello.qn | git diff --no-index examples/hello.txt -
-      - name: Upload quench-lsp for next job
+      - name: Upload quench for next job
         uses: actions/upload-artifact@v2
         with:
-          name: quench-lsp
-          path: '~/.cargo/bin/quench-lsp'
+          name: quench
+          path: '~/.cargo/bin/quench'
       - name: Ensure empty Git status
         run: "$GITHUB_WORKSPACE/report_git_status.sh"
 
@@ -95,18 +95,18 @@ jobs:
         run: npm install
       - name: Package
         run: npx vsce package
-      - name: Download quench-lsp from previous job
+      - name: Download quench from previous job
         uses: actions/download-artifact@v2
         with:
-          name: quench-lsp
-      - name: Make quench-lsp executable
+          name: quench
+      - name: Make quench executable
         # https://stackoverflow.com/a/53637605
         run: |
           VERSION=$(node -e "console.log(require('./package.json').version);")
-          FILE="$HOME/.quench/$VERSION/bin"
-          chmod +x $GITHUB_WORKSPACE/quench-lsp
-          mkdir -p "$FILE"
-          mv $GITHUB_WORKSPACE/quench-lsp "$FILE"
+          DIR="$HOME/.quench/$VERSION/bin"
+          chmod +x $GITHUB_WORKSPACE/quench
+          mkdir -p "$DIR"
+          mv $GITHUB_WORKSPACE/quench "$DIR"
       - name: Run tests
         run: xvfb-run -a npm test
       - name: Ensure empty Git status

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,15 +38,6 @@ jobs:
           asset_path: ./target/release/quench${{ matrix.extension }}
           asset_name: quench-${{ matrix.platform }}${{ matrix.extension }}
           asset_content_type: application/octet-stream
-      - name: Upload quench-lsp
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./target/release/quench-lsp${{ matrix.extension }}
-          asset_name: quench-lsp-${{ matrix.platform }}${{ matrix.extension }}
-          asset_content_type: application/octet-stream
 
   crates-io:
     runs-on: ubuntu-20.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,6 @@ include = [
   "/src",
   "/tree-sitter-quench/src",
 ]
-default-run = "quench"
-
-[[bin]]
-name = "quench-lsp"
-path = "src/bin/quench-lsp.rs"
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Save [quench-windows.exe][] as `quench.exe` somewhere on your PATH.
 
 ## Usage
 
-On a Unix-like system, pass `--help` to the binary you just installed:
+Pass `--help` to the binary you just installed:
 
 ```sh
 quench --help

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -31,9 +31,11 @@ Then compile:
 npm run compile
 ```
 
-Next, from VS Code, press F5 to open a new window with this extension loaded.
-Then open a Quench source file (such as `examples/hello.qn` from this
-repository) to activate it as normal.
+Next, from VS Code, press F5 to open a new window with this extension loaded. To
+avoid developing with a mismatched version of Quench itself, you may also need
+to build Quench from source and change the `quench.server.path` setting to point
+to the binary you've built. Then open a Quench source file (such as
+`examples/hello.qn` from this repository) to activate it as normal.
 
 [lsp]: https://microsoft.github.io/language-server-protocol/
 [marketplace]: https://marketplace.visualstudio.com/items?itemName=quench.quench

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -44,7 +44,7 @@
             "string"
           ],
           "default": null,
-          "description": "Path to quench-lsp executable."
+          "description": "Path to quench executable."
         },
         "quench.trace.server": {
           "scope": "window",

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -11,7 +11,7 @@ import * as lsp from 'vscode-languageclient/node';
 let client: lsp.LanguageClient;
 
 function defaultServerPath(version: string, ext: string): string {
-  return path.join(os.homedir(), '.quench', version, 'bin', `quench-lsp${ext}`);
+  return path.join(os.homedir(), '.quench', version, 'bin', `quench${ext}`);
 }
 
 function serverPath(version: string, ext: string): string {
@@ -37,7 +37,7 @@ function start(command: string) {
   client = new lsp.LanguageClient(
     'quench',
     'Quench',
-    { command },
+    { command, args: ["lsp"] },
     { documentSelector: [{ scheme: 'file', language: 'quench' }] },
   );
   client.start();
@@ -64,7 +64,7 @@ export async function activate(context: vscode.ExtensionContext) {
       download,
     );
     if (userResponse === download) {
-      const url = `https://github.com/quench-lang/quench/releases/download/v${version}/quench-lsp-${platform}${ext}`;
+      const url = `https://github.com/quench-lang/quench/releases/download/v${version}/quench-${platform}${ext}`;
       // https://stackoverflow.com/a/11944984
       https.get(url, (response: any) => {
         const { statusCode } = response;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ mod parser;
 mod text;
 
 pub mod db;
+pub mod lsp;

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,9 +1,9 @@
 mod state {
+    use crate::db::{self, EditError};
     use lspower::lsp::{
         Diagnostic, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
         DidOpenTextDocumentParams, MessageType, SemanticToken,
     };
-    use quench::db::{self, EditError};
     use std::{fmt::Debug, thread};
     use tokio::sync::{mpsc, oneshot};
     use url::Url;
@@ -160,6 +160,7 @@ mod state {
     }
 }
 
+use crate::db;
 use lspower::{
     jsonrpc::{Error, ErrorCode, Result},
     lsp::{
@@ -171,7 +172,6 @@ use lspower::{
     },
     Client, LanguageServer, LspService, Server,
 };
-use quench::db;
 use state::LspMessage;
 use std::sync::Arc;
 use url::Url;
@@ -281,7 +281,7 @@ impl LanguageServer for Backend {
 }
 
 #[tokio::main]
-async fn main() {
+pub async fn main() {
     let state = state::State::new();
     let (service, messages) = LspService::new(|client| Backend {
         client,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -22,7 +22,7 @@ fn test_examples() {
         let path = entry.unwrap().path();
         if path.extension() == Some(OsStr::new("qn")) {
             let mut cmd = Command::cargo_bin("quench").unwrap();
-            let assert = cmd.arg(&path).assert().success().stderr("");
+            let assert = cmd.arg("run").arg(&path).assert().success().stderr("");
 
             let mut file = mint
                 .new_goldenfile(path.with_extension("txt").file_name().unwrap())

--- a/tests/goldenfiles/help.txt
+++ b/tests/goldenfiles/help.txt
@@ -5,12 +5,16 @@ Here is an example Quench program:
     #!/usr/bin/env quench
     print("Hello, world!");
 
-Save the above contents as hello.qn and run these commands:
+Save the above contents as hello.qn and run this command:
+
+    quench run hello.qn
+
+Or on a Unix-like system, you could instead run these two commands:
 
     chmod +x hello.qn
     ./hello.qn
 
-You should see this output:
+Either way, you should see this output:
 
     AST:
 
@@ -21,12 +25,13 @@ You should see this output:
 As you can see, Quench can parse your program, but can't run it yet. Stay tuned!
 
 USAGE:
-    quench <file> [args]...
+    quench <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
-ARGS:
-    <file>       Source file to run as a script
-    <args>...    Arguments to pass to the script
+SUBCOMMANDS:
+    help    Prints this message or the help of the given subcommand(s)
+    lsp     Starts the language server
+    run     Runs a script


### PR DESCRIPTION
I'm basically copying [Deno's subcommand structure](https://deno.land/manual@v1.8.2/getting_started/setup_your_environment#lsp-clients) here, while still allowing shebangs via some observations I noted in #3: namely, that the path to a script run with a shebang seems to always contain a slash. Currently there are only two binaries so it isn't a huge deal, but subcommands should help prevent the proliferation of binaries in the future.