### PR TITLE
Don't let YAML gobble my shell quotes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Install Astring
         run: npm install
       - name: Ensure empty Git status
-        run: "$GITHUB_WORKSPACE/report_git_status.sh"
+        run: |
+          "$GITHUB_WORKSPACE/report_git_status.sh"
 
   tree-sitter:
     runs-on: ubuntu-20.04
@@ -42,7 +43,8 @@ jobs:
       - name: Test parser
         run: npx tree-sitter test
       - name: Ensure empty Git status
-        run: "$GITHUB_WORKSPACE/report_git_status.sh"
+        run: |
+          "$GITHUB_WORKSPACE/report_git_status.sh"
 
   package:
     runs-on: ubuntu-20.04
@@ -59,7 +61,8 @@ jobs:
       - name: Package
         run: cargo package
       - name: Ensure empty Git status
-        run: "$GITHUB_WORKSPACE/report_git_status.sh"
+        run: |
+          "$GITHUB_WORKSPACE/report_git_status.sh"
 
   rust:
     strategy:
@@ -93,7 +96,8 @@ jobs:
           name: quench
           path: '~/.cargo/bin/quench'
       - name: Ensure empty Git status
-        run: "$GITHUB_WORKSPACE/report_git_status.sh"
+        run: |
+          "$GITHUB_WORKSPACE/report_git_status.sh"
 
   vscode:
     needs: rust
@@ -127,4 +131,5 @@ jobs:
       - name: Run tests
         run: xvfb-run -a npm test
       - name: Ensure empty Git status
-        run: "$GITHUB_WORKSPACE/report_git_status.sh"
+        run: |
+          "$GITHUB_WORKSPACE/report_git_status.sh"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Publish
         run: cargo publish --token ${{ secrets.CARGO_TOKEN }}
       - name: Ensure empty Git status
-        run: "$GITHUB_WORKSPACE/report_git_status.sh"
+        run: |
+          "$GITHUB_WORKSPACE/report_git_status.sh"
 
   vscode-marketplace:
     runs-on: ubuntu-20.04
@@ -72,4 +73,5 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
       - name: Ensure empty Git status
-        run: "$GITHUB_WORKSPACE/report_git_status.sh"
+        run: |
+          "$GITHUB_WORKSPACE/report_git_status.sh"


### PR DESCRIPTION
The double quotes are meant to [prevent globbing and word splitting](https://github.com/koalaman/shellcheck/wiki/SC2086), However, currently, without a `|`, those quotes are consumed by YAML, as you can see via the [`yq`](https://mikefarah.gitbook.io/yq/) tool:
```sh
echo 'run: $GITHUB_WORKSPACE/report_git_status.sh' | yq eval --tojson -
echo 'run: "$GITHUB_WORKSPACE/report_git_status.sh"' | yq eval --tojson -
```
Both of the above two commands give the same output:
```json
{
  "run": "$GITHUB_WORKSPACE/report_git_status.sh"
}
```
In contrast, this preserves the quotes:
```sh
echo $'run: |\n  "$GITHUB_WORKSPACE/report_git_status.sh"' | yq eval --tojson -
```
Output:
```json
{
  "run": "\"$GITHUB_WORKSPACE/report_git_status.sh\"\n"
}
```