### PR TITLE
Remove the "Development tools" category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 categories = [
   "command-line-utilities",
   "compilers",
-  "development-tools",
 ]
 include = [
   "/astring-quench/node_modules/astring/LICENSE",


### PR DESCRIPTION
I didn't realize that it's specifically referring to Rust development tools, which Quench is not.