### PR TITLE
Define Rust types for Quench ASTs

### DIFF
--- a/examples/complicated.js
+++ b/examples/complicated.js
@@ -1,3 +1,4 @@
 console.log("foo");
 console.log(console.log("bar"));
 console.log("👻 ba # not a comment\nz 🙃");
+console.log("foo", "bar", "baz");

--- a/examples/complicated.qn
+++ b/examples/complicated.qn
@@ -8,3 +8,6 @@ print(
 );
 print("👻 ba # not a comment
 z 🙃");
+
+# multiple arguments
+print("foo", "bar", "baz");

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -20,7 +20,7 @@ impl Codegen {
         Codegen { js_runtime }
     }
 
-    pub fn gen(&mut self, ast: estree::Program) -> Option<String> {
+    pub fn gen(&mut self, ast: &estree::Program) -> Option<String> {
         let context = self.js_runtime.global_context();
         let scope = &mut rusty_v8::HandleScope::with_context(self.js_runtime.v8_isolate(), context);
         let context = scope.get_current_context();
@@ -73,7 +73,7 @@ mod tests {
             })],
         };
         let mut codegen = Codegen::new();
-        let code = codegen.gen(ast).unwrap();
+        let code = codegen.gen(&ast).unwrap();
         assert_eq!(code, "console.log(\"Hello, world!\");\n");
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -67,11 +67,9 @@ fn compile_expression(expr: &syntax::Expr) -> Result<estree::Expression, im::Vec
 }
 
 fn compile_statement(stmt: &syntax::Stmt) -> Result<estree::Statement, im::Vector<Diagnostic>> {
-    match stmt {
-        syntax::Stmt::Expr(expr) => Ok(estree::Statement::Expression {
-            expression: Box::new(compile_expression(expr)?),
-        }),
-    }
+    Ok(estree::Statement::Expression {
+        expression: Box::new(compile_expression(&stmt.expression)?),
+    })
 }
 
 pub fn compile_file(file: &syntax::File) -> Result<estree::Program, im::Vector<Diagnostic>> {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,0 +1,64 @@
+use crate::{estree, syntax};
+use either::Either;
+
+fn compile_identifier(id: &syntax::Identifier) -> Option<estree::Expression> {
+    match id.name.as_str() {
+        "print" => Some(estree::Expression::Member {
+            object: Box::new(estree::Expression::Identifier {
+                name: String::from("console"),
+            }),
+            property: Box::new(estree::Expression::Identifier {
+                name: String::from("log"),
+            }),
+            computed: false,
+        }),
+        "args" => Some(estree::Expression::Member {
+            object: Box::new(estree::Expression::Identifier {
+                name: String::from("Deno"),
+            }),
+            property: Box::new(estree::Expression::Identifier {
+                name: String::from("args"),
+            }),
+            computed: false,
+        }),
+        _ => None,
+    }
+}
+
+fn compile_expression(expr: &syntax::Expression) -> Option<estree::Expression> {
+    match expr {
+        syntax::Expression::Call(syntax::Call {
+            function,
+            arguments,
+        }) => Some(estree::Expression::Call {
+            callee: Box::new(compile_identifier(function)?),
+            arguments: arguments.iter().filter_map(compile_expression).collect(),
+        }),
+        syntax::Expression::Id(id) => compile_identifier(id),
+        syntax::Expression::Lit(syntax::Literal::Str(value)) => Some(estree::Expression::Literal {
+            value: estree::Value::String(value.clone()),
+        }),
+    }
+}
+
+fn compile_statement(stmt: &syntax::Statement) -> Option<estree::Statement> {
+    match stmt {
+        syntax::Statement::Expr(expr) => {
+            let compiled = compile_expression(expr)?;
+            Some(estree::Statement::Expression {
+                expression: Box::new(compiled),
+            })
+        }
+    }
+}
+
+pub fn compile_file(file: &syntax::File) -> Option<estree::Program> {
+    Some(estree::Program {
+        body: file
+            .body
+            .iter()
+            .filter_map(compile_statement)
+            .map(Either::Right)
+            .collect(),
+    })
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,10 @@
-use crate::{compiler, estree, parser, syntax, text};
+use crate::{compiler, diagnosis::Diagnostic, estree, parser, syntax, text};
 use lspower::lsp::{
-    Diagnostic, DiagnosticSeverity, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, Position, Range, SemanticToken, SemanticTokenType,
+    DiagnosticSeverity, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, Position, SemanticToken, SemanticTokenType,
     TextDocumentContentChangeEvent,
 };
-use std::{fmt::Debug, ptr, rc::Rc};
+use std::{fmt::Debug, ptr, rc::Rc, sync::Arc};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use tree_sitter::{Node, Point, Tree};
@@ -56,13 +56,13 @@ pub trait QueryGroup: salsa::Database {
 
     fn cst(&self, key: Url) -> Option<Rc<Cst>>;
 
-    fn diagnostics(&self, key: Url) -> im::Vector<Diagnostic>;
+    fn cst_diagnostics(&self, key: Url) -> im::Vector<Diagnostic>;
 
     fn semantic_tokens(&self, key: Url) -> im::Vector<SemanticToken>;
 
-    fn ast(&self, key: Url) -> Option<Rc<syntax::File>>;
+    fn ast(&self, key: Url) -> Result<Rc<syntax::File>, im::Vector<Diagnostic>>;
 
-    fn compile(&self, key: Url) -> Option<Rc<estree::Program>>;
+    fn compile(&self, key: Url) -> Result<Arc<estree::Program>, im::Vector<Diagnostic>>;
 }
 
 fn source_index(db: &dyn QueryGroup, key: Url) -> Option<text::Index> {
@@ -70,6 +70,15 @@ fn source_index(db: &dyn QueryGroup, key: Url) -> Option<text::Index> {
         Some(text::Index::new(&db.source_text(key)))
     } else {
         None
+    }
+}
+
+pub struct IndexRequest(pub Url);
+
+impl Processable<Option<text::Index>> for IndexRequest {
+    fn process(self, db: &mut Database) -> Option<text::Index> {
+        let IndexRequest(uri) = self;
+        db.source_index(uri)
     }
 }
 
@@ -215,22 +224,13 @@ impl Processable<Result<(), NotYetOpenedError>> for DidCloseTextDocumentParams {
     }
 }
 
-fn make_diagnostic(range: Range, message: String, severity: DiagnosticSeverity) -> Diagnostic {
-    let mut diag = Diagnostic::new_simple(range, message);
-    diag.severity = Some(severity);
-    diag
-}
-
 fn diagnostics_helper(node: &Node, index: &text::Index) -> im::Vector<Diagnostic> {
     if node.is_error() || node.is_missing() {
-        im::vector![make_diagnostic(
-            Range::new(
-                index.to_lsp(node.start_position()),
-                index.to_lsp(node.end_position()),
-            ),
-            format!("syntax {}", node.to_sexp()),
-            DiagnosticSeverity::Error,
-        )]
+        im::vector![Diagnostic {
+            range: node.range(),
+            severity: DiagnosticSeverity::Error,
+            message: format!("syntax {}", node.to_sexp()),
+        }]
     } else {
         let mut diagnostics = im::vector![];
         let mut cursor = node.walk();
@@ -241,19 +241,10 @@ fn diagnostics_helper(node: &Node, index: &text::Index) -> im::Vector<Diagnostic
     }
 }
 
-fn diagnostics(db: &dyn QueryGroup, key: Url) -> im::Vector<Diagnostic> {
+fn cst_diagnostics(db: &dyn QueryGroup, key: Url) -> im::Vector<Diagnostic> {
     match (db.source_index(key.clone()), db.cst(key)) {
         (Some(index), Some(tree)) => diagnostics_helper(&tree.0.root_node(), &index),
         _ => im::vector![],
-    }
-}
-
-pub struct DiagnosticsRequest(pub Url);
-
-impl Processable<im::Vector<Diagnostic>> for DiagnosticsRequest {
-    fn process(self, db: &mut Database) -> im::Vector<Diagnostic> {
-        let DiagnosticsRequest(uri) = self;
-        db.diagnostics(uri)
     }
 }
 
@@ -378,21 +369,38 @@ impl Processable<im::Vector<SemanticToken>> for TokensRequest {
     }
 }
 
-fn ast(db: &dyn QueryGroup, key: Url) -> Option<Rc<syntax::File>> {
-    let tree = db.cst(key.clone())?;
-    let source = db.source_text(key); // at this point we already know the key is valid
-    syntax::Node::make(&source, &tree.0.root_node()).map(Rc::new)
+fn ast(db: &dyn QueryGroup, key: Url) -> Result<Rc<syntax::File>, im::Vector<Diagnostic>> {
+    let cst_diags = db.cst_diagnostics(key.clone());
+    if !cst_diags.is_empty() {
+        Err(cst_diags)
+    } else {
+        let tree = db.cst(key.clone()).ok_or(im::vector![])?;
+        let source = db.source_text(key); // at this point we already know the key is valid
+        syntax::Node::make(&source, &tree.0.root_node()).map(Rc::new)
+    }
 }
 
-pub fn compile(db: &dyn QueryGroup, key: Url) -> Option<Rc<estree::Program>> {
+pub fn compile(
+    db: &dyn QueryGroup,
+    key: Url,
+) -> Result<Arc<estree::Program>, im::Vector<Diagnostic>> {
     let tree = db.ast(key.clone())?;
-    compiler::compile_file(&tree).map(Rc::new)
+    compiler::compile_file(&tree).map(Arc::new)
+}
+
+pub struct CompileRequest(pub Url);
+
+impl Processable<Result<Arc<estree::Program>, im::Vector<Diagnostic>>> for CompileRequest {
+    fn process(self, db: &mut Database) -> Result<Arc<estree::Program>, im::Vector<Diagnostic>> {
+        let CompileRequest(uri) = self;
+        db.compile(uri)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lspower::lsp::VersionedTextDocumentIdentifier;
+    use lspower::lsp::{Range, VersionedTextDocumentIdentifier};
     use pretty_assertions::assert_eq;
 
     fn foo_db(text: String) -> (Database, Url) {
@@ -438,7 +446,7 @@ mod tests {
         assert_eq!(db.opened_files(), im::hashset![]);
     }
 
-    fn make_range(
+    fn lsp_range(
         start_line: u32,
         start_character: u32,
         end_line: u32,
@@ -459,7 +467,7 @@ mod tests {
                 version: 2,
             },
             content_changes: vec![TextDocumentContentChangeEvent {
-                range: Some(make_range(0, 0, 0, 3)),
+                range: Some(lsp_range(0, 0, 0, 3)),
                 range_length: None,
                 text: String::from("bar"),
             }],
@@ -494,23 +502,43 @@ mod tests {
         assert_eq!(new_contents, "bar");
     }
 
-    fn make_error(sl: u32, sc: u32, el: u32, ec: u32, message: &str) -> Diagnostic {
-        make_diagnostic(
-            make_range(sl, sc, el, ec),
-            String::from(message),
-            DiagnosticSeverity::Error,
-        )
+    fn ts_range(
+        sb: usize,
+        sp: (usize, usize),
+        eb: usize,
+        ep: (usize, usize),
+    ) -> tree_sitter::Range {
+        tree_sitter::Range {
+            start_byte: sb,
+            start_point: Point::new(sp.0, sp.1),
+            end_byte: eb,
+            end_point: Point::new(ep.0, ep.1),
+        }
+    }
+
+    fn make_error(
+        sb: usize,
+        sp: (usize, usize),
+        eb: usize,
+        ep: (usize, usize),
+        message: &str,
+    ) -> Diagnostic {
+        Diagnostic {
+            range: ts_range(sb, sp, eb, ep),
+            severity: DiagnosticSeverity::Error,
+            message: String::from(message),
+        }
     }
 
     #[test]
     fn test_diagnostics_hello_world() {
         let (db, uri) = foo_db(slurp::read_all_to_string("examples/errors.qn").unwrap());
-        let diagnostics = db.diagnostics(uri);
+        let diagnostics = db.cst_diagnostics(uri);
         assert_eq!(
             diagnostics,
             im::vector![
-                make_error(0, 6, 0, 14, "syntax (ERROR (string))"),
-                make_error(0, 24, 0, 24, "syntax (MISSING \";\")"),
+                make_error(6, (0, 6), 14, (0, 14), "syntax (ERROR (string))"),
+                make_error(24, (0, 24), 24, (0, 24), "syntax (MISSING \";\")"),
             ],
         );
     }
@@ -565,21 +593,21 @@ mod tests {
     fn test_ast_hello_world() {
         let (db, uri) = foo_db(slurp::read_all_to_string("examples/hello.qn").unwrap());
         let tree = db.ast(uri).unwrap();
-        assert_eq!(
-            tree.as_ref(),
-            &syntax::File {
-                body: vec![syntax::Statement::Expr(syntax::Expression::Call(
-                    syntax::Call {
-                        function: syntax::Identifier {
-                            name: String::from("print")
-                        },
-                        arguments: vec![syntax::Expression::Lit(syntax::Literal::Str(
-                            String::from("Hello, world!")
-                        ))],
-                    }
-                ))]
-            }
-        );
+        let expected = syntax::File {
+            range: ts_range(0, (0, 0), 47, (3, 0)),
+            body: vec![syntax::Stmt::Expr(syntax::Expr::Call(syntax::Call {
+                range: ts_range(23, (2, 0), 45, (2, 22)),
+                function: syntax::Id {
+                    range: ts_range(23, (2, 0), 28, (2, 5)),
+                    name: String::from("print"),
+                },
+                arguments: vec![syntax::Expr::Lit(syntax::Lit::Str(syntax::Str {
+                    range: ts_range(29, (2, 6), 44, (2, 21)),
+                    value: String::from("Hello, world!"),
+                }))],
+            }))],
+        };
+        assert_eq!(tree.as_ref(), &expected);
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -595,17 +595,20 @@ mod tests {
         let tree = db.ast(uri).unwrap();
         let expected = syntax::File {
             range: ts_range(0, (0, 0), 47, (3, 0)),
-            body: vec![syntax::Stmt::Expr(syntax::Expr::Call(syntax::Call {
-                range: ts_range(23, (2, 0), 45, (2, 22)),
-                function: syntax::Id {
-                    range: ts_range(23, (2, 0), 28, (2, 5)),
-                    name: String::from("print"),
-                },
-                arguments: vec![syntax::Expr::Lit(syntax::Lit::Str(syntax::Str {
-                    range: ts_range(29, (2, 6), 44, (2, 21)),
-                    value: String::from("Hello, world!"),
-                }))],
-            }))],
+            body: vec![syntax::Stmt {
+                range: ts_range(23, (2, 0), 46, (2, 23)),
+                expression: syntax::Expr::Call(syntax::Call {
+                    range: ts_range(23, (2, 0), 45, (2, 22)),
+                    function: syntax::Id {
+                        range: ts_range(23, (2, 0), 28, (2, 5)),
+                        name: String::from("print"),
+                    },
+                    arguments: vec![syntax::Expr::Lit(syntax::Lit::Str(syntax::Str {
+                        range: ts_range(29, (2, 6), 44, (2, 21)),
+                        value: String::from("Hello, world!"),
+                    }))],
+                }),
+            }],
         };
         assert_eq!(tree.as_ref(), &expected);
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,4 @@
-use crate::{estree, parser, syntax, text};
-use either::Either;
+use crate::{compiler, estree, parser, syntax, text};
 use lspower::lsp::{
     Diagnostic, DiagnosticSeverity, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, Position, Range, SemanticToken, SemanticTokenType,
@@ -385,71 +384,9 @@ fn ast(db: &dyn QueryGroup, key: Url) -> Option<Rc<syntax::File>> {
     syntax::Node::make(&source, &tree.0.root_node()).map(Rc::new)
 }
 
-fn compile_identifier(id: &syntax::Identifier) -> Option<estree::Expression> {
-    match id.name.as_str() {
-        "print" => Some(estree::Expression::Member {
-            object: Box::new(estree::Expression::Identifier {
-                name: String::from("console"),
-            }),
-            property: Box::new(estree::Expression::Identifier {
-                name: String::from("log"),
-            }),
-            computed: false,
-        }),
-        "args" => Some(estree::Expression::Member {
-            object: Box::new(estree::Expression::Identifier {
-                name: String::from("Deno"),
-            }),
-            property: Box::new(estree::Expression::Identifier {
-                name: String::from("args"),
-            }),
-            computed: false,
-        }),
-        _ => None,
-    }
-}
-
-fn compile_expression(expr: &syntax::Expression) -> Option<estree::Expression> {
-    match expr {
-        syntax::Expression::Call(syntax::Call {
-            function,
-            arguments,
-        }) => Some(estree::Expression::Call {
-            callee: Box::new(compile_identifier(function)?),
-            arguments: arguments.iter().filter_map(compile_expression).collect(),
-        }),
-        syntax::Expression::Id(id) => compile_identifier(id),
-        syntax::Expression::Lit(syntax::Literal::Str(value)) => Some(estree::Expression::Literal {
-            value: estree::Value::String(value.clone()),
-        }),
-    }
-}
-
-fn compile_statement(stmt: &syntax::Statement) -> Option<estree::Statement> {
-    match stmt {
-        syntax::Statement::Expr(expr) => {
-            let compiled = compile_expression(expr)?;
-            Some(estree::Statement::Expression {
-                expression: Box::new(compiled),
-            })
-        }
-    }
-}
-
-fn compile_file(file: &syntax::File) -> Option<estree::Program> {
-    Some(estree::Program {
-        body: file
-            .body
-            .iter()
-            .filter_map(compile_statement)
-            .map(Either::Right)
-            .collect(),
-    })
-}
-
 pub fn compile(db: &dyn QueryGroup, key: Url) -> Option<Rc<estree::Program>> {
     let tree = db.ast(key.clone())?;
-    compile_file(&tree).map(Rc::new)
+    compiler::compile_file(&tree).map(Rc::new)
 }
 
 #[cfg(test)]

--- a/src/diagnosis.rs
+++ b/src/diagnosis.rs
@@ -1,0 +1,9 @@
+use lspower::lsp::DiagnosticSeverity;
+use tree_sitter::Range;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Diagnostic {
+    pub range: Range,
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod codegen;
+mod compiler;
 mod db;
 #[allow(dead_code)]
 mod estree;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod db;
 mod estree;
 mod lsp;
 mod parser;
+mod syntax;
 mod text;
 
 use crate::{codegen::Codegen, db::QueryGroup};
@@ -58,7 +59,7 @@ fn compile(file: PathBuf) -> anyhow::Result<String> {
     let diagnostics = db.diagnostics(uri.clone());
     if diagnostics.is_empty() {
         db.compile(uri)
-            .and_then(|compiled| Codegen::new().gen(compiled))
+            .and_then(|compiled| Codegen::new().gen(compiled.as_ref()))
             .ok_or(anyhow::anyhow!("Failed to compile."))
     } else {
         for lspower::lsp::Diagnostic {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,102 +1,197 @@
+use crate::diagnosis::Diagnostic;
+use lspower::lsp::DiagnosticSeverity;
+use std::fmt::Debug;
+use tree_sitter::Range;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct File {
-    pub body: Vec<Statement>,
+    pub range: Range,
+    pub body: Vec<Stmt>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Statement {
-    Expr(Expression),
+pub enum Stmt {
+    Expr(Expr),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Expression {
-    Lit(Literal),
-    Id(Identifier),
+pub enum Expr {
+    Lit(Lit),
+    Id(Id),
     Call(Call),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Literal {
-    Str(String),
+pub enum Lit {
+    Str(Str),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Identifier {
+pub struct Str {
+    pub range: Range,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Id {
+    pub range: Range,
     pub name: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Call {
-    pub function: Identifier,
-    pub arguments: Vec<Expression>,
+    pub range: Range,
+    pub function: Id,
+    pub arguments: Vec<Expr>,
 }
 
 pub trait Node {
-    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self>
+    fn make(text: &str, node: &tree_sitter::Node) -> Result<Self, im::Vector<Diagnostic>>
     where
         Self: Sized;
+
+    fn range(&self) -> Range;
+}
+
+fn make_children<T: Debug + Node>(
+    text: &str,
+    parent: &tree_sitter::Node,
+) -> Result<Vec<T>, im::Vector<Diagnostic>> {
+    let mut cursor = parent.walk();
+    let (children, diagnosticses): (Vec<_>, Vec<_>) = parent
+        .children(&mut cursor)
+        .filter(|child| child.kind() != "comment" && child.kind() != ";") // TODO: make this good
+        .map(|child| T::make(text, &child))
+        .partition(Result::is_ok);
+    if diagnosticses.is_empty() {
+        Ok(children.into_iter().map(Result::unwrap).collect())
+    } else {
+        let mut flattened = im::vector![];
+        for diagnostics in diagnosticses.into_iter().map(Result::unwrap_err) {
+            flattened.append(diagnostics);
+        }
+        Err(flattened)
+    }
 }
 
 impl Node for File {
-    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
-        let mut cursor = node.walk();
-        Some(File {
-            body: node
-                .children(&mut cursor)
-                .filter_map(|child| Statement::make(text, &child))
-                .collect(),
+    fn make(text: &str, node: &tree_sitter::Node) -> Result<Self, im::Vector<Diagnostic>> {
+        Ok(File {
+            range: node.range(),
+            body: make_children(text, node)?,
         })
     }
-}
 
-impl Node for Statement {
-    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
-        Expression::make(text, node).map(Statement::Expr)
+    fn range(&self) -> Range {
+        self.range
     }
 }
 
-impl Node for Expression {
-    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
-        match node.kind() {
-            "string" => Literal::make(text, node).map(Expression::Lit),
-            "identifier" => Identifier::make(text, node).map(Expression::Id),
-            "call" => Call::make(text, node).map(Expression::Call),
-            _ => None,
+impl Node for Stmt {
+    fn make(text: &str, node: &tree_sitter::Node) -> Result<Self, im::Vector<Diagnostic>> {
+        Expr::make(text, node).map(Stmt::Expr)
+    }
+
+    fn range(&self) -> Range {
+        match self {
+            Stmt::Expr(x) => x.range(),
         }
     }
 }
 
-impl Node for Literal {
-    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
-        let value = node
-            .utf8_text(text.as_bytes())
-            .ok()?
-            .strip_prefix("\"")?
-            .strip_suffix("\"")?;
-        Some(Literal::Str(String::from(value)))
+impl Node for Expr {
+    fn make(text: &str, node: &tree_sitter::Node) -> Result<Self, im::Vector<Diagnostic>> {
+        match node.kind() {
+            "string" => Lit::make(text, node).map(Expr::Lit),
+            "identifier" => Id::make(text, node).map(Expr::Id),
+            "call" => Call::make(text, node).map(Expr::Call),
+            kind => Err(im::vector![Diagnostic {
+                range: node.range(),
+                severity: DiagnosticSeverity::Error,
+                message: format!("did not expect a node of kind {}", kind),
+            }]),
+        }
+    }
+
+    fn range(&self) -> Range {
+        match self {
+            Expr::Lit(x) => x.range(),
+            Expr::Id(x) => x.range(),
+            Expr::Call(x) => x.range(),
+        }
     }
 }
 
-impl Node for Identifier {
-    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
-        Some(Identifier {
-            name: String::from(node.utf8_text(text.as_bytes()).ok()?),
+impl Node for Lit {
+    fn make(text: &str, node: &tree_sitter::Node) -> Result<Self, im::Vector<Diagnostic>> {
+        Str::make(text, node).map(Lit::Str)
+    }
+
+    fn range(&self) -> Range {
+        match self {
+            Lit::Str(x) => x.range(),
+        }
+    }
+}
+
+impl Node for Str {
+    fn make(text: &str, node: &tree_sitter::Node) -> Result<Self, im::Vector<Diagnostic>> {
+        // we assume UTF-8, and our grammar guarantees that the string starts and ends with quotes
+        let value = node
+            .utf8_text(text.as_bytes())
+            .unwrap()
+            .strip_prefix("\"")
+            .unwrap()
+            .strip_suffix("\"")
+            .unwrap();
+        Ok(Str {
+            range: node.range(),
+            value: String::from(value),
         })
+    }
+
+    fn range(&self) -> Range {
+        self.range
+    }
+}
+
+impl Node for Id {
+    fn make(text: &str, node: &tree_sitter::Node) -> Result<Self, im::Vector<Diagnostic>> {
+        Ok(Id {
+            range: node.range(),
+            name: String::from(node.utf8_text(text.as_bytes()).unwrap()), // we assume UTF-8
+        })
+    }
+
+    fn range(&self) -> Range {
+        self.range
     }
 }
 
 impl Node for Call {
-    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
-        Some(Call {
-            function: Identifier::make(text, &node.child_by_field_name("function")?)?,
-            arguments: {
-                let args_child = node.child_by_field_name("arguments")?;
-                let mut cursor = args_child.walk();
-                args_child
-                    .children(&mut cursor)
-                    .filter_map(|child| Expression::make(text, &child))
-                    .collect()
-            },
+    fn make(text: &str, node: &tree_sitter::Node) -> Result<Self, im::Vector<Diagnostic>> {
+        let function = node.child_by_field_name("function").ok_or_else(|| {
+            im::vector![Diagnostic {
+                range: node.range(),
+                severity: DiagnosticSeverity::Error,
+                message: String::from("expected a function name"),
+            }]
+        })?;
+        let arguments = node.child_by_field_name("arguments").ok_or_else(|| {
+            im::vector![Diagnostic {
+                range: node.range(),
+                severity: DiagnosticSeverity::Error,
+                message: String::from("expected a list of arguments"),
+            }]
+        })?;
+        Ok(Call {
+            range: node.range(),
+            function: Id::make(text, &function)?,
+            arguments: make_children(text, &arguments)?,
         })
+    }
+
+    fn range(&self) -> Range {
+        self.range
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,0 +1,102 @@
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct File {
+    pub body: Vec<Statement>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Statement {
+    Expr(Expression),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Expression {
+    Lit(Literal),
+    Id(Identifier),
+    Call(Call),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Literal {
+    Str(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Identifier {
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Call {
+    pub function: Identifier,
+    pub arguments: Vec<Expression>,
+}
+
+pub trait Node {
+    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl Node for File {
+    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
+        let mut cursor = node.walk();
+        Some(File {
+            body: node
+                .children(&mut cursor)
+                .filter_map(|child| Statement::make(text, &child))
+                .collect(),
+        })
+    }
+}
+
+impl Node for Statement {
+    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
+        Expression::make(text, node).map(Statement::Expr)
+    }
+}
+
+impl Node for Expression {
+    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
+        match node.kind() {
+            "string" => Literal::make(text, node).map(Expression::Lit),
+            "identifier" => Identifier::make(text, node).map(Expression::Id),
+            "call" => Call::make(text, node).map(Expression::Call),
+            _ => None,
+        }
+    }
+}
+
+impl Node for Literal {
+    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
+        let value = node
+            .utf8_text(text.as_bytes())
+            .ok()?
+            .strip_prefix("\"")?
+            .strip_suffix("\"")?;
+        Some(Literal::Str(String::from(value)))
+    }
+}
+
+impl Node for Identifier {
+    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
+        Some(Identifier {
+            name: String::from(node.utf8_text(text.as_bytes()).ok()?),
+        })
+    }
+}
+
+impl Node for Call {
+    fn make(text: &str, node: &tree_sitter::Node) -> Option<Self> {
+        Some(Call {
+            function: Identifier::make(text, &node.child_by_field_name("function")?)?,
+            arguments: {
+                let args_child = node.child_by_field_name("arguments")?;
+                let mut cursor = args_child.walk();
+                args_child
+                    .children(&mut cursor)
+                    .filter_map(|child| Expression::make(text, &child))
+                    .collect()
+            },
+        })
+    }
+}

--- a/tests/goldenfiles/examples.yml
+++ b/tests/goldenfiles/examples.yml
@@ -17,7 +17,7 @@ errors:
   compile: |
     0:6 to 0:14 Error: syntax (ERROR (string))
     0:24 to 0:24 Error: syntax (MISSING ";")
-    Error: Failed to parse.
+    Error: Failed to compile.
 
 hello:
   out: |

--- a/tests/goldenfiles/examples.yml
+++ b/tests/goldenfiles/examples.yml
@@ -12,6 +12,7 @@ complicated:
     undefined
     👻 ba # not a comment
     z 🙃
+    foo bar baz
 
 errors:
   compile: |

--- a/tree-sitter-quench/corpus/hello.txt
+++ b/tree-sitter-quench/corpus/hello.txt
@@ -10,7 +10,8 @@ print("Hello, world!");
 
 (source_file
   (comment)
-  (call
-    function: (identifier)
-    arguments: (arguments
-      (string))))
+  body: (statement
+    expression: (call
+      function: (identifier)
+      arguments: (arguments
+        argument: (string)))))

--- a/tree-sitter-quench/grammar.js
+++ b/tree-sitter-quench/grammar.js
@@ -4,11 +4,11 @@ module.exports = grammar({
   extras: $ => [/\s/, $.comment],
 
   rules: {
-    source_file: $ => repeat($._statement),
+    source_file: $ => repeat(field('body', $.statement)),
 
     comment: $ => /#.*/,
 
-    _statement: $ => seq(choice($._expression), ';'),
+    statement: $ => seq(field('expression', $._expression), ';'),
 
     _expression: $ => choice($._literal, $.identifier, $.call),
 
@@ -26,8 +26,8 @@ module.exports = grammar({
     ),
 
     arguments: $ => seq(
-      $._expression,
-      repeat(seq(',', $._expression)),
+      field('argument', $._expression),
+      repeat(seq(',', field('argument', $._expression))),
       optional(','),
     ),
   },

--- a/tree-sitter-quench/src/grammar.json
+++ b/tree-sitter-quench/src/grammar.json
@@ -4,25 +4,28 @@
     "source_file": {
       "type": "REPEAT",
       "content": {
-        "type": "SYMBOL",
-        "name": "_statement"
+        "type": "FIELD",
+        "name": "body",
+        "content": {
+          "type": "SYMBOL",
+          "name": "statement"
+        }
       }
     },
     "comment": {
       "type": "PATTERN",
       "value": "#.*"
     },
-    "_statement": {
+    "statement": {
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            }
-          ]
+          "type": "FIELD",
+          "name": "expression",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
         },
         {
           "type": "STRING",
@@ -97,8 +100,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
         },
         {
           "type": "REPEAT",
@@ -110,8 +117,12 @@
                 "value": ","
               },
               {
-                "type": "SYMBOL",
-                "name": "_expression"
+                "type": "FIELD",
+                "name": "argument",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
               }
             ]
           }

--- a/tree-sitter-quench/src/node-types.json
+++ b/tree-sitter-quench/src/node-types.json
@@ -2,24 +2,25 @@
   {
     "type": "arguments",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "call",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "string",
-          "named": true
-        }
-      ]
+    "fields": {
+      "argument": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "call",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -51,24 +52,41 @@
   {
     "type": "source_file",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "call",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "string",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "statement",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "statement",
+    "named": true,
+    "fields": {
+      "expression": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "call",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/tree-sitter-quench/src/parser.c
+++ b/tree-sitter-quench/src/parser.c
@@ -6,13 +6,13 @@
 #endif
 
 #define LANGUAGE_VERSION 12
-#define STATE_COUNT 18
+#define STATE_COUNT 19
 #define LARGE_STATE_COUNT 4
 #define SYMBOL_COUNT 16
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 8
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 2
+#define FIELD_COUNT 5
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
 
 enum {
@@ -24,7 +24,7 @@ enum {
   anon_sym_RPAREN = 6,
   anon_sym_COMMA = 7,
   sym_source_file = 8,
-  sym__statement = 9,
+  sym_statement = 9,
   sym__expression = 10,
   sym__literal = 11,
   sym_call = 12,
@@ -43,7 +43,7 @@ static const char *ts_symbol_names[] = {
   [anon_sym_RPAREN] = ")",
   [anon_sym_COMMA] = ",",
   [sym_source_file] = "source_file",
-  [sym__statement] = "_statement",
+  [sym_statement] = "statement",
   [sym__expression] = "_expression",
   [sym__literal] = "_literal",
   [sym_call] = "call",
@@ -62,7 +62,7 @@ static TSSymbol ts_symbol_map[] = {
   [anon_sym_RPAREN] = anon_sym_RPAREN,
   [anon_sym_COMMA] = anon_sym_COMMA,
   [sym_source_file] = sym_source_file,
-  [sym__statement] = sym__statement,
+  [sym_statement] = sym_statement,
   [sym__expression] = sym__expression,
   [sym__literal] = sym__literal,
   [sym_call] = sym_call,
@@ -108,8 +108,8 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym__statement] = {
-    .visible = false,
+  [sym_statement] = {
+    .visible = true,
     .named = true,
   },
   [sym__expression] = {
@@ -139,27 +139,60 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
 };
 
 enum {
-  field_arguments = 1,
-  field_function = 2,
+  field_argument = 1,
+  field_arguments = 2,
+  field_body = 3,
+  field_expression = 4,
+  field_function = 5,
 };
 
 static const char *ts_field_names[] = {
   [0] = NULL,
+  [field_argument] = "argument",
   [field_arguments] = "arguments",
+  [field_body] = "body",
+  [field_expression] = "expression",
   [field_function] = "function",
 };
 
-static const TSFieldMapSlice ts_field_map_slices[2] = {
-  [1] = {.index = 0, .length = 2},
+static const TSFieldMapSlice ts_field_map_slices[10] = {
+  [1] = {.index = 0, .length = 1},
+  [2] = {.index = 1, .length = 1},
+  [3] = {.index = 2, .length = 1},
+  [4] = {.index = 3, .length = 2},
+  [5] = {.index = 5, .length = 1},
+  [6] = {.index = 6, .length = 2},
+  [7] = {.index = 8, .length = 2},
+  [8] = {.index = 10, .length = 1},
+  [9] = {.index = 11, .length = 2},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
+    {field_body, 0},
+  [1] =
+    {field_body, 0, .inherited = true},
+  [2] =
+    {field_expression, 0},
+  [3] =
+    {field_body, 0, .inherited = true},
+    {field_body, 1, .inherited = true},
+  [5] =
+    {field_argument, 0},
+  [6] =
+    {field_argument, 0},
+    {field_argument, 1, .inherited = true},
+  [8] =
     {field_arguments, 2},
     {field_function, 0},
+  [10] =
+    {field_argument, 1},
+  [11] =
+    {field_argument, 0, .inherited = true},
+    {field_argument, 1, .inherited = true},
 };
 
-static TSSymbol ts_alias_sequences[2][MAX_ALIAS_SEQUENCE_LENGTH] = {
+static TSSymbol ts_alias_sequences[10][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
 };
 
@@ -246,6 +279,7 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [15] = {.lex_state = 0},
   [16] = {.lex_state = 0},
   [17] = {.lex_state = 0},
+  [18] = {.lex_state = 0},
 };
 
 static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -260,11 +294,11 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_COMMA] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(15),
-    [sym__statement] = STATE(2),
-    [sym__expression] = STATE(16),
-    [sym__literal] = STATE(16),
-    [sym_call] = STATE(16),
+    [sym_source_file] = STATE(16),
+    [sym_statement] = STATE(9),
+    [sym__expression] = STATE(17),
+    [sym__literal] = STATE(17),
+    [sym_call] = STATE(17),
     [aux_sym_source_file_repeat1] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(5),
     [sym_comment] = ACTIONS(3),
@@ -272,10 +306,10 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identifier] = ACTIONS(9),
   },
   [2] = {
-    [sym__statement] = STATE(3),
-    [sym__expression] = STATE(16),
-    [sym__literal] = STATE(16),
-    [sym_call] = STATE(16),
+    [sym_statement] = STATE(9),
+    [sym__expression] = STATE(17),
+    [sym__literal] = STATE(17),
+    [sym_call] = STATE(17),
     [aux_sym_source_file_repeat1] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(11),
     [sym_comment] = ACTIONS(3),
@@ -283,10 +317,10 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identifier] = ACTIONS(9),
   },
   [3] = {
-    [sym__statement] = STATE(3),
-    [sym__expression] = STATE(16),
-    [sym__literal] = STATE(16),
-    [sym_call] = STATE(16),
+    [sym_statement] = STATE(9),
+    [sym__expression] = STATE(17),
+    [sym__literal] = STATE(17),
+    [sym_call] = STATE(17),
     [aux_sym_source_file_repeat1] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(13),
     [sym_comment] = ACTIONS(3),
@@ -303,9 +337,9 @@ static uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(21), 1,
       sym_string,
-    STATE(17), 1,
+    STATE(18), 1,
       sym_arguments,
-    STATE(10), 3,
+    STATE(11), 3,
       sym__expression,
       sym__literal,
       sym_call,
@@ -318,7 +352,7 @@ static uint16_t ts_small_parse_table[] = {
       sym_string,
     ACTIONS(25), 1,
       anon_sym_RPAREN,
-    STATE(14), 3,
+    STATE(15), 3,
       sym__expression,
       sym__literal,
       sym_call,
@@ -331,7 +365,7 @@ static uint16_t ts_small_parse_table[] = {
       sym_string,
     ACTIONS(27), 1,
       anon_sym_RPAREN,
-    STATE(14), 3,
+    STATE(15), 3,
       sym__expression,
       sym__literal,
       sym_call,
@@ -342,7 +376,7 @@ static uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(23), 1,
       sym_string,
-    STATE(14), 3,
+    STATE(15), 3,
       sym__expression,
       sym__literal,
       sym_call,
@@ -362,60 +396,67 @@ static uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
       sym_string,
       sym_identifier,
-  [90] = 4,
+  [90] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(35), 1,
-      anon_sym_RPAREN,
+    ACTIONS(35), 3,
+      ts_builtin_sym_end,
+      sym_string,
+      sym_identifier,
+  [99] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(37), 1,
-      anon_sym_COMMA,
-    STATE(11), 1,
-      aux_sym_arguments_repeat1,
-  [103] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(25), 1,
       anon_sym_RPAREN,
     ACTIONS(39), 1,
       anon_sym_COMMA,
-    STATE(13), 1,
+    STATE(12), 1,
       aux_sym_arguments_repeat1,
-  [116] = 2,
+  [112] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(41), 3,
-      anon_sym_SEMI,
+    ACTIONS(41), 1,
       anon_sym_RPAREN,
-      anon_sym_COMMA,
-  [125] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
     ACTIONS(43), 1,
-      anon_sym_RPAREN,
-    ACTIONS(45), 1,
       anon_sym_COMMA,
-    STATE(13), 1,
+    STATE(14), 1,
       aux_sym_arguments_repeat1,
-  [138] = 2,
+  [125] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(43), 2,
+    ACTIONS(45), 3,
+      anon_sym_SEMI,
       anon_sym_RPAREN,
       anon_sym_COMMA,
-  [146] = 2,
+  [134] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(48), 1,
+    ACTIONS(47), 1,
+      anon_sym_RPAREN,
+    ACTIONS(49), 1,
+      anon_sym_COMMA,
+    STATE(14), 1,
+      aux_sym_arguments_repeat1,
+  [147] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(52), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [155] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(54), 1,
       ts_builtin_sym_end,
-  [153] = 2,
+  [162] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(50), 1,
+    ACTIONS(56), 1,
       anon_sym_SEMI,
-  [160] = 2,
+  [169] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(52), 1,
+    ACTIONS(58), 1,
       anon_sym_RPAREN,
 };
 
@@ -427,13 +468,14 @@ static uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(8)] = 69,
   [SMALL_STATE(9)] = 81,
   [SMALL_STATE(10)] = 90,
-  [SMALL_STATE(11)] = 103,
-  [SMALL_STATE(12)] = 116,
+  [SMALL_STATE(11)] = 99,
+  [SMALL_STATE(12)] = 112,
   [SMALL_STATE(13)] = 125,
-  [SMALL_STATE(14)] = 138,
-  [SMALL_STATE(15)] = 146,
-  [SMALL_STATE(16)] = 153,
-  [SMALL_STATE(17)] = 160,
+  [SMALL_STATE(14)] = 134,
+  [SMALL_STATE(15)] = 147,
+  [SMALL_STATE(16)] = 155,
+  [SMALL_STATE(17)] = 162,
+  [SMALL_STATE(18)] = 169,
 };
 
 static TSParseActionEntry ts_parse_actions[] = {
@@ -441,28 +483,31 @@ static TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
   [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [11] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
-  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
-  [15] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(16),
-  [18] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(8),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 2),
-  [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 3),
+  [11] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, .production_id = 2),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 4),
+  [15] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 4), SHIFT_REPEAT(17),
+  [18] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 4), SHIFT_REPEAT(8),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 2, .production_id = 5),
+  [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 3, .production_id = 6),
   [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
   [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statement, 2),
-  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 1),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_call, 4, .production_id = 1),
-  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2),
-  [45] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2), SHIFT_REPEAT(7),
-  [48] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [50] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [52] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 1, .production_id = 1),
+  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_statement, 2, .production_id = 3),
+  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 1, .production_id = 5),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 2, .production_id = 6),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_call, 4, .production_id = 7),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, .production_id = 9),
+  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, .production_id = 9), SHIFT_REPEAT(7),
+  [52] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, .production_id = 8),
+  [54] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [56] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Similar to #56, this PR adds handwritten type definitions for syntax trees that already have a fairly dynamic representation: in this case, that representation is [`tree_sitter::Node`](https://docs.rs/tree-sitter/0.17.1/tree_sitter/struct.Node.html).

To do this, I also had to write functions that translate from Tree-sitter's generic representation to my typed representation, which kind of made me have to confront the fact that now I have several stages of compilation, most of which can produce errors which the user should be able to receive as diagnostics with source locations. Therefore, I restructured the pipeline a bit so now any stage can return a vector of diagnostics.

As a side note, it's a bit distracting to see three generated files in `tree-sitter-quench/src` appear in the diff of this PR, so I'll probably see if I can follow up with a change to ignore those in Git and instead just generate them in CI by adding a dependency between jobs (and also include them in the source bundle when uploading to crates.io).