### PR TITLE
Drop Windows support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
           - platform: macos
             label: macos-10.15
             extension: ''
-          - platform: windows
-            label: windows-2019
-            extension: '.exe'
+          # - platform: windows
+          #   label: windows-2019
+          #   extension: '.exe'
     runs-on: ${{ matrix.label }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo mv quench /usr/local/bin
 
 ### Windows
 
-Save [quench-windows.exe][] as `quench.exe` somewhere on your PATH.
+Windows is currently unsupported.
 
 ## Usage
 


### PR DESCRIPTION
I got stuck on #60, so instead I'm just dropping Windows support, hopefully temporarily. I'm keeping some of the logic for Windows, though (essentially as dead code), because it'd be more trouble to remove it (especially if I'm hoping to enable it again soon).