### PR TITLE
Use default import for Immutable.js

### DIFF
--- a/examples/args.js
+++ b/examples/args.js
@@ -1,4 +1,4 @@
-import * as Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
 var main = function (_) {
   return console.log(Deno.args);
 };

--- a/examples/complicated.js
+++ b/examples/complicated.js
@@ -1,4 +1,4 @@
-import * as Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
 var main = function (_) {
   return (function () {
     console.log("foo");

--- a/examples/data.js
+++ b/examples/data.js
@@ -1,4 +1,4 @@
-import * as Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
 var my_null = null;
 var my_boolean = true;
 var my_other_boolean = false;

--- a/examples/hello.js
+++ b/examples/hello.js
@@ -1,4 +1,4 @@
-import * as Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
 var main = function (_) {
   return console.log("Hello, world!");
 };

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -23,7 +23,7 @@ const MAIN: &str = "main";
 
 pub fn compile_file(file: &qn::File) -> Result<js::Program, im::Vector<Diagnostic>> {
     let mut body = vec![Either::Right(js::ModuleDeclaration::Import {
-        specifiers: vec![js::ImportSpecifier::ImportNamespace {
+        specifiers: vec![js::ImportSpecifier::ImportDefault {
             local: js::Identifier {
                 name: String::from("Immutable"),
             },

--- a/src/db.rs
+++ b/src/db.rs
@@ -653,7 +653,7 @@ mod tests {
                         "type": "ImportDeclaration",
                         "specifiers": [
                             {
-                                "type": "ImportNamespaceSpecifier",
+                                "type": "ImportDefaultSpecifier",
                                 "local": {
                                     "type": "Identifier",
                                     "name": "Immutable"


### PR DESCRIPTION
I didn't realize that [Immutable.js provides a default export](https://github.com/oguimbal/immutable-js-deno/blob/4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js#L5759-L5817), but this simplifies the generated JS code a bit.