### PR TITLE
Start a standard library

### DIFF
--- a/examples/args.js
+++ b/examples/args.js
@@ -1,4 +1,4 @@
-import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+import Immutable from "https://example.com/quench.js";
 var main = function (_) {
   return console.log(Deno.args);
 };

--- a/examples/complicated.js
+++ b/examples/complicated.js
@@ -1,4 +1,4 @@
-import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+import Immutable from "https://example.com/quench.js";
 var main = function (_) {
   return (function () {
     console.log("foo");

--- a/examples/data.js
+++ b/examples/data.js
@@ -1,4 +1,4 @@
-import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+import Immutable from "https://example.com/quench.js";
 var my_null = null;
 var my_boolean = true;
 var my_other_boolean = false;

--- a/examples/hello.js
+++ b/examples/hello.js
@@ -1,4 +1,4 @@
-import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+import Immutable from "https://example.com/quench.js";
 var main = function (_) {
   return console.log("Hello, world!");
 };

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,4 +1,4 @@
-use crate::estree;
+use crate::{deps, estree};
 
 pub struct Codegen {
     js_runtime: deno_core::JsRuntime,
@@ -8,14 +8,7 @@ impl Codegen {
     pub fn new() -> Self {
         let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions::default());
         js_runtime
-            .execute(
-                concat!(
-                    "https://github.com/quench-lang/quench/raw/",
-                    env!("VERGEN_GIT_SHA"),
-                    "/jsdeps/node_modules/astring/dist/astring.min.js",
-                ),
-                include_str!("../jsdeps/node_modules/astring/dist/astring.min.js"),
-            )
+            .execute(deps::ASTRING, deps::ASTRING_SOURCE)
             .unwrap(); // this shouldn't fail since the Astring source is a compile-time constant
         Codegen { js_runtime }
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,4 +1,4 @@
-use crate::{deps, diagnosis::Diagnostic, estree as js, syntax as qn};
+use crate::{diagnosis::Diagnostic, estree as js, opts::Opts, syntax as qn};
 use either::Either;
 use lspower::lsp::DiagnosticSeverity;
 use std::fmt::Debug;
@@ -21,7 +21,7 @@ fn gather<T, U: Debug>(
 
 const MAIN: &str = "main";
 
-pub fn compile_file(file: &qn::File) -> Result<js::Program, im::Vector<Diagnostic>> {
+pub fn compile_file(file: &qn::File, opts: &Opts) -> Result<js::Program, im::Vector<Diagnostic>> {
     let mut body = vec![Either::Right(js::ModuleDeclaration::Import {
         specifiers: vec![js::ImportSpecifier::ImportDefault {
             local: js::Identifier {
@@ -29,7 +29,7 @@ pub fn compile_file(file: &qn::File) -> Result<js::Program, im::Vector<Diagnosti
             },
         }],
         source: js::Literal::Literal {
-            value: js::Value::String(String::from(deps::IMMUTABLE)),
+            value: js::Value::String(String::from(opts.stdlib())),
         },
     })];
     body.extend(

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,2 +1,24 @@
-pub const IMMUTABLE: &str =
+pub const ASTRING: &str = concat!(
+    "https://github.com/quench-lang/quench/raw/",
+    env!("VERGEN_GIT_SHA"),
+    "/jsdeps/node_modules/astring/dist/astring.min.js",
+);
+pub const ASTRING_SOURCE: &str = include_str!("../jsdeps/node_modules/astring/dist/astring.min.js");
+
+pub const STDLIB_PLACEHOLDER: &str = "https://example.com/quench.js";
+pub const STDLIB: &str = concat!(
+    "https://github.com/quench-lang/quench/raw/",
+    env!("VERGEN_GIT_SHA"),
+    "/src/stdlib.js",
+);
+pub const STDLIB_SOURCE: &str = include_str!("stdlib.js");
+
+pub const IMMUTABLE_SPECIFIED: &str =
     "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+pub const IMMUTABLE_FOUND: &str = concat!(
+    "https://github.com/quench-lang/quench/raw/",
+    env!("VERGEN_GIT_SHA"),
+    "/jsdeps/node_modules/immutable/dist/immutable.es.js",
+);
+pub const IMMUTABLE_SOURCE: &str =
+    include_str!("../jsdeps/node_modules/immutable/dist/immutable.es.js");

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,0 +1,16 @@
+use crate::deps;
+
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct Opts {
+    pub stdlib_placeholder: bool,
+}
+
+impl Opts {
+    pub fn stdlib(&self) -> &str {
+        if self.stdlib_placeholder {
+            deps::STDLIB_PLACEHOLDER
+        } else {
+            deps::STDLIB
+        }
+    }
+}

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -1,0 +1,2 @@
+import Immutable from "https://deno.land/x/immutable@4.0.0-rc.12/node_modules/immutable/dist/immutable.es.js";
+export default Immutable;

--- a/tests/goldenfiles/help.txt
+++ b/tests/goldenfiles/help.txt
@@ -19,11 +19,12 @@ Either way, you should see this output:
     Hello, world!
 
 USAGE:
-    quench <SUBCOMMAND>
+    quench [FLAGS] <SUBCOMMAND>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help                  Prints help information
+        --stdlib-placeholder    Replaces stdlib import with an example.com placeholder
+    -V, --version               Prints version information
 
 SUBCOMMANDS:
     compile    Compiles a file to JavaScript


### PR DESCRIPTION
The goal is to write most of the standard library in Quench, but some of it needs to be written in JavaScript, and in any case, it all needs to end up as JavaScript before it can be executed, whether it's manually written in JavaScript or not. This PR does the necessary refactoring to support such a standard library, although currently it only imports and then re-exports Immutable.js.

The `--stdlib-placeholder` CLI arg is to avoid having to put Quench Git repo commit hashes in expected test output, while still staying compatible with Deno when that arg is not passed.