### PR TITLE
Run scheduled CI monthly instead of weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 1 * *'
 
 jobs:
   jsdeps:


### PR DESCRIPTION
This should help with the cache difficulties that prevented me from merging #70 earlier, since [there doesn't seem to be a way to manually clear the cache](https://github.com/actions/cache/issues/2), but [apparently cache is automatically cleared after a week](https://github.com/actions/cache/tree/v2.1.6#cache-limits):

> Caches that are not accessed within the last week will also be evicted.